### PR TITLE
fix(create-monots): add `templates` folder

### DIFF
--- a/.changeset/sixty-spiders-beam.md
+++ b/.changeset/sixty-spiders-beam.md
@@ -1,0 +1,5 @@
+---
+'create-monots': patch
+---
+
+Add the `templates` folder to the published `create-monots` package.

--- a/packages/create-monots/package.json
+++ b/packages/create-monots/package.json
@@ -16,7 +16,8 @@
     "create-monots": "./dist/index.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "dependencies": {
     "@swc/core": "^1.2.108",


### PR DESCRIPTION
### Description

Add the `templates` folder to the published `create-monots` package.

