### PR TITLE
fix(cli): minify binary file

### DIFF
--- a/.changeset/gentle-rice-tease.md
+++ b/.changeset/gentle-rice-tease.md
@@ -1,0 +1,6 @@
+---
+'create-monots': patch
+'@monots/cli': patch
+---
+
+Change `engines` field to only support node version with built in `esm` support.

--- a/.changeset/smooth-colts-compete.md
+++ b/.changeset/smooth-colts-compete.md
@@ -1,0 +1,5 @@
+---
+'@monots/core': minor
+---
+
+Make sure to minify the build output for packages with `"mode": "cli"`. This will speed up `create-monots` and `@monots/cli`.

--- a/.changeset/unlucky-plums-raise.md
+++ b/.changeset/unlucky-plums-raise.md
@@ -1,0 +1,7 @@
+---
+'create-monots': minor
+'@monots/cli': minor
+'@monots/core': minor
+---
+
+Copy over `.` (dot) files when working with templates.

--- a/packages/create-monots/package.json
+++ b/packages/create-monots/package.json
@@ -46,7 +46,7 @@
     "validate-npm-package-name": "^3.0.0"
   },
   "engines": {
-    "node": ">= 12.2.0 || >=14.13.0"
+    "node": "^12.2.0 || ^14.13.0 || ^16"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-monots/src/create-monots.ts
+++ b/packages/create-monots/src/create-monots.ts
@@ -185,14 +185,12 @@ export async function createMonotsProject(props: CreateMonotsProjectProps): Prom
   await pnpmInstall(root);
   console.log();
 
-  const relativePath = path.join(process.cwd(), appName) === appPath ? appName : appPath;
-
   console.log(`${chalk.green('Success!')} Created ${appName} at ${appPath}`);
   console.log('Inside that directory, you can run all the monots commands:');
   console.log();
   console.log('We suggest that you begin by typing:');
   console.log();
-  console.log(chalk.cyan('  cd'), relativePath);
+  console.log(chalk.cyan('  cd'), appName);
   console.log(`  ${chalk.cyan(`${displayedCommand} install`)}`);
   console.log();
   console.log(

--- a/packages/create-monots/src/helpers/git.ts
+++ b/packages/create-monots/src/helpers/git.ts
@@ -44,7 +44,7 @@ export async function tryGitInit(root: string): Promise<boolean> {
     await exec('git checkout -b main');
 
     await exec('git add -A');
-    await exec('git commit -m "Initial commit from Create Next App"');
+    await exec('git commit -m "feat: getting started with monots 🎉🥳"');
     return true;
   } catch {
     if (didInit) {

--- a/packages/monots__cli/package.json
+++ b/packages/monots__cli/package.json
@@ -40,7 +40,7 @@
     "type-fest": "^2.5.3"
   },
   "engines": {
-    "node": ">= 12.2.0 || >=14.13.0"
+    "node": "^12.2.0 || ^14.13.0 || ^16"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/monots__core/src/helpers/bundle-with-esbuild.ts
+++ b/packages/monots__core/src/helpers/bundle-with-esbuild.ts
@@ -18,7 +18,7 @@ export async function bundleWithEsbuild(pkg: PackageEntity) {
       await build({
         entryPoints: [entrypoint.source],
         outfile: path.join(pkg.output, `${entrypoint.baseName || 'index'}.cjs`),
-        // minify: true,
+        minify: true,
         sourcemap: false,
         bundle: true,
         external: [...builtins, 'esbuild', '@swc/core'],

--- a/packages/monots__core/src/helpers/core.ts
+++ b/packages/monots__core/src/helpers/core.ts
@@ -137,6 +137,7 @@ export async function copyTemplate(props: CopyTemplateProps) {
   };
 
   await copy(input, output, {
+    dot: true,
     rename: (filename) => template(filename)(variablesWithCasing).replace(/.template$/, ''),
     transform: (filename) => {
       if (path.extname(filename) !== '.template') {


### PR DESCRIPTION
### Description

- Change `engines` field to only support node version with built in `esm` support for `create-monots` and `@monots/cli`.
- Make sure to minify the build output for packages with `"mode": "cli"`. This will speed up `create-monots` and `@monots/cli`.
- Copy over `.` (dot) files when working with templates.
